### PR TITLE
fix: misspelled 'wodc' -> 'wdoc' model option

### DIFF
--- a/legalnlp/get_premodel.py
+++ b/legalnlp/get_premodel.py
@@ -15,7 +15,7 @@ def get_premodel(model):
             zip_ref.extractall(d+filename.replace('.zip', ''))
         modelv = True
     # Download files to use in Word2Vec and Doc2Vec
-    if model == 'wodc':
+    if model == 'wdoc':
         url2 = 'https://ndownloader.figshare.com/files/30446736'
         filename2 = wget.download(url2, out=d)
         if d == None:


### PR DESCRIPTION
In the README the `Word2Vec/Doc2Vec` option reads '*wdoc*', but in the download script it's configured as '*wodc*', disallowing the model download.